### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Anycubic Card
-## Home Asssistant card for Anycubic Printers (via the Anycubic Cloud integration)
+## Home Assistant card for Anycubic Printers (via the Anycubic Cloud integration)
 
 
 ## Features


### PR DESCRIPTION
## Summary
- fix Home Assistant typo in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_68836b428b188321ad9f4376166d1ffa